### PR TITLE
Update player.cpp to fix blade and blunt armor rating calc

### DIFF
--- a/src/util/player/player.cpp
+++ b/src/util/player/player.cpp
@@ -175,7 +175,7 @@ namespace util {
         }
 
         if (mod::mod_manager::get_singleton()->get_blade_and_blunt()) {
-            auto resistance = a_armor_rating * game_settings->get_armor_scaling_factor() + 0.03f * 100 * a_pieces_worn;
+            auto resistance = a_armor_rating * game_settings->get_armor_scaling_factor();
 
             return mod::blade_and_blunt::calculate_armor_damage_resistance(resistance);
         }


### PR DESCRIPTION
Fix for the incorrect damage resistance calculation when using Blade and Blunt. It seems that the current version is adding an armor bonus for each worn piece of equipment, which is not part of BaB's armor calculation.

As far as I can tell the blade and blunt armor calc in `/src/mod/blade_and_blunt.cpp` is correct, it's just this one line that is causing it to calculate incorrectly. 